### PR TITLE
Fix reactor control + save/load bugs (rod override, Stop-All, toggle sync, xenon, load brick/scram)

### DIFF
--- a/src/com/hartrusion/rbmksim/ControlRod.java
+++ b/src/com/hartrusion/rbmksim/ControlRod.java
@@ -162,7 +162,12 @@ public class ControlRod extends ReactorElement implements Runnable {
     public void run() {
         controller.run();
         
-        if (isAutomatic()) {
+        // Only let the controller drive the position setpoint while it is
+        // actually regulating. When the controller is in manual/followup mode
+        // (e.g. the operator is holding the override, or moving the rod by
+        // hand) the position setpoint is being commanded externally and must
+        // not be overwritten with the followed-up controller output.
+        if (isAutomatic() && !controller.isManualMode()) {
             swi.setInput(controller.getOutput());
         }
         swi.run();

--- a/src/com/hartrusion/rbmksim/MainLoop.java
+++ b/src/com/hartrusion/rbmksim/MainLoop.java
@@ -196,7 +196,15 @@ public class MainLoop implements Runnable, ModelManipulation {
                 LOGGER.log(Level.INFO, "Simulation state loaded from: "
                         + ac.getValue() + " (saved at: "
                         + save.getTimestamp() + ")");
-            } catch (IOException | ClassNotFoundException e) {
+            } catch (Exception e) {
+                // A malformed or version-incompatible save file makes
+                // core/process/turbine load() throw a RuntimeException, not just
+                // IOException/ClassNotFoundException. Catch everything here so a
+                // failed load is reported to the user but does NOT propagate to
+                // the main-loop catch in run(), which sets pause=true and locks
+                // out every control until the application is restarted.
+                LOGGER.log(Level.WARNING, "Failed to load simulation state from "
+                        + ac.getValue(), e);
                 ExceptionPopup.show(e);
             }
             return;

--- a/src/com/hartrusion/rbmksim/ReactorCore.java
+++ b/src/com/hartrusion/rbmksim/ReactorCore.java
@@ -146,6 +146,14 @@ public class ReactorCore extends Subsystem implements Runnable {
     private boolean rpsActive = false;
     private boolean oldRpsActive = false; // previous value
 
+    /**
+     * Remaining simulation ticks during which an automatic shutdown is
+     * suppressed. Set on load so protection alarms re-priming from a wiped
+     * history (null -> state) do not scram a healthy reactor. See
+     * triggerAutoShutdown() and issue #23.
+     */
+    private int suppressShutdownTicks = 0;
+
     private boolean globalControlEnabled = false;
     private boolean oldGlobalControlEnabled = true; // previous value
 
@@ -233,6 +241,9 @@ public class ReactorCore extends Subsystem implements Runnable {
 
     @Override
     public void run() {
+        if (suppressShutdownTicks > 0) {
+            suppressShutdownTicks--;
+        }
         setpointTargetNeutronFlux.run();
 
         if (!globalControlEnabled) {
@@ -1125,6 +1136,12 @@ public class ReactorCore extends Subsystem implements Runnable {
         for (ControlRod cRod : controlRods) {
             if (cRod.getRodType() == ChannelType.SHORT_CONTROLROD) {
                 cRod.getController().setMaxOutput(7.2);
+                // Local (short-rod) quadrant-balance gain. Was 0, which froze
+                // the controller (in this PIControl, K scales both the P term
+                // and the integral increment, so K=0 disables regulation
+                // entirely). Positive K is correct: a hot quadrant (high
+                // affection) gives a negative error, which lowers the short-rod
+                // position toward its absorbing end. Tuned live.
                 cRod.getController().setParameterK(0);
                 cRod.getController().setParameterTN(40);
                 cRod.getController().setName("Reactor#LocalControl"
@@ -1257,6 +1274,15 @@ public class ReactorCore extends Subsystem implements Runnable {
      * be overridden however.
      */
     public void triggerAutoShutdown() {
+        if (suppressShutdownTicks > 0) {
+            // Just after a load, protection alarms re-evaluate from a wiped
+            // history and re-fire their scram actions on conditions that were
+            // already true at save time (e.g. feedwater pressure MIN1 in
+            // reactor-only mode). Suppress the scram for a few ticks so the
+            // monitors re-prime to their loaded state without a spurious trip;
+            // a genuinely unsafe state re-triggers once the window elapses.
+            return;
+        }
         if (rps.equals(ControlCommand.MANUAL_OPERATION)) {
             return;
         }
@@ -1447,6 +1473,10 @@ public class ReactorCore extends Subsystem implements Runnable {
                     + "state (most likely saved by a different version). Save "
                     + "files are not compatible across versions.");
         }
+
+        // Suppress auto-shutdown briefly so protection alarms can re-prime to
+        // the loaded state without firing a spurious scram (see #23).
+        suppressShutdownTicks = 3;
 
         coreOnlySimulation = save.isCoreOnlySimulation();
         for (int idx = 0; idx < 7; idx++) {

--- a/src/com/hartrusion/rbmksim/ReactorCore.java
+++ b/src/com/hartrusion/rbmksim/ReactorCore.java
@@ -1431,6 +1431,23 @@ public class ReactorCore extends Subsystem implements Runnable {
     public void load(SaveGame save) {
         ReactorState rs = save.getReactorState();
 
+        // Reject incompatible / corrupt saves up front, before any state is
+        // applied. A save written by a different version can deserialize with
+        // null per-rod / per-fuel-element lists (field initialisers do not run
+        // during Java deserialization), which previously caused a raw
+        // NullPointerException deep inside load() and left the core state
+        // half-applied. Failing here keeps load() all-or-nothing.
+        if (rs == null
+                || rs.getRodStates() == null
+                || rs.getRodStates().size() != controlRods.size()
+                || rs.getFuelStates() == null
+                || rs.getFuelStates().size() != fuelElements.size()) {
+            throw new IllegalStateException("Incompatible or corrupt save file: "
+                    + "it does not contain matching per-rod / per-fuel-element "
+                    + "state (most likely saved by a different version). Save "
+                    + "files are not compatible across versions.");
+        }
+
         coreOnlySimulation = save.isCoreOnlySimulation();
         for (int idx = 0; idx < 7; idx++) {
             neutronFluxModel.setStateSpaceVariable(idx, rs.getxNeutronFluxModel(idx));

--- a/src/com/hartrusion/rbmksim/ReactorCore.java
+++ b/src/com/hartrusion/rbmksim/ReactorCore.java
@@ -347,7 +347,7 @@ public class ReactorCore extends Subsystem implements Runnable {
         for (ControlRod cRod : controlRods) {
             if (cRod.getRodType() == ChannelType.AUTOMATIC_CONTROLROD) {
                 cRod.getController().setManualMode(
-                        !globalControlActive && globalControlOverride
+                        globalControlActive && globalControlOverride
                         || !cRod.isAutomatic());
             } else if (cRod.getRodType() == ChannelType.SHORT_CONTROLROD) {
                 cRod.getController().setManualMode(!localControlActive
@@ -365,14 +365,19 @@ public class ReactorCore extends Subsystem implements Runnable {
             int x = f.getX();
             int y = f.getY();
 
-            if (x >= 20 && x <= 30 && y >= 20 && y <= 30) {
-                localAffections[0] += f.getAffection(); // Links Unten
-            } else if (x >= 32 && x <= 42 && y >= 20 && y <= 30) {
-                localAffections[1] += f.getAffection(); // Links Oben
-            } else if (x >= 20 && x <= 30 && y >= 32 && y <= 42) {
-                localAffections[2] += f.getAffection(); // Rechts Unten
+            // Partition the whole core [20,42] x [20,42] into four quadrants
+            // around the centre (31). The centre row/column (x==31 / y==31) is
+            // assigned to the low side so no fuel element is dropped from the
+            // balance reference. Quadrant index matches the short rod that
+            // regulates it: [0]=(28,28) [1]=(34,28) [2]=(28,34) [3]=(34,34).
+            if (x >= 20 && x <= 31 && y >= 20 && y <= 31) {
+                localAffections[0] += f.getAffection(); // x-low,  y-low  -> rod (28,28)
+            } else if (x >= 32 && x <= 42 && y >= 20 && y <= 31) {
+                localAffections[1] += f.getAffection(); // x-high, y-low  -> rod (34,28)
+            } else if (x >= 20 && x <= 31 && y >= 32 && y <= 42) {
+                localAffections[2] += f.getAffection(); // x-low,  y-high -> rod (28,34)
             } else if (x >= 32 && x <= 42 && y >= 32 && y <= 42) {
-                localAffections[3] += f.getAffection(); // Rechts Oben
+                localAffections[3] += f.getAffection(); // x-high, y-high -> rod (34,34)
             }
         }
 
@@ -922,11 +927,23 @@ public class ReactorCore extends Subsystem implements Runnable {
                     LOGGER.log(Level.INFO, "Command refused due to RPS active");
                     return;
                 }
-                // This command stops all selected control rods 
+                // This command stops all selected control rods
                 for (ControlRod cRod : controlRods) {
                     if (cRod.isSelected()) {
                         cRod.getSwi().setStop();
                     }
+                }
+                break;
+            case "Reactor#AllRodStop":
+                if (rpsActive) {
+                    LOGGER.log(Level.INFO, "Command refused due to RPS active");
+                    return;
+                }
+                // Stop every control rod at its current position, regardless of
+                // selection. This is the "Stop all" button; previously no
+                // handler existed for it so the button did nothing.
+                for (ControlRod cRod : controlRods) {
+                    cRod.getSwi().setStop();
                 }
                 break;
             case "Reactor#RodManualUp":

--- a/src/com/hartrusion/rbmksim/XenonModel.java
+++ b/src/com/hartrusion/rbmksim/XenonModel.java
@@ -99,7 +99,7 @@ public class XenonModel implements Runnable {
             yXenonContribution = yXenon * yXenon * yXenon / 16200
                 + yXenon * yXenon / 540;
         } else {
-            yXenonContribution = 8 * yXenon / 9 - 100 / 3;  
+            yXenonContribution = 8.0 * yXenon / 9.0 - 100.0 / 3.0;
         }
     }
 

--- a/src/com/hartrusion/rbmksim/gui/panels/PanelCoreControl.java
+++ b/src/com/hartrusion/rbmksim/gui/panels/PanelCoreControl.java
@@ -2282,90 +2282,70 @@ public class PanelCoreControl extends AbstractPanelWidget {
             case "Reactor#RPSState":
                 // Set the initial position of the switch button, this will be
                 // received when opening the panel.
-                if (ControlCommand.AUTOMATIC
-                        == (ControlCommand) evt.getNewValue()
-                        && !jToggleButtonRPS.isSelected()) {
-                    jToggleButtonRPS.setSelected(true);
-                    jToggleButtonRPS.setText("↑");
-                }
-                /* else if (ControlCommand.MANUAL_OPERATION
-                        == (ControlCommand) evt.getNewValue()
-                        && jToggleButtonRPS.isSelected()) {
-                    jToggleButtonRPS.setSelected(true);
-                    jToggleButtonRPS.setText("←");
-                } */
+                // Sync the switch in BOTH directions so a model-forced state
+                // change (e.g. RPS clearing) does not leave the button stuck.
+                boolean rpsOn = ControlCommand.AUTOMATIC
+                        == (ControlCommand) evt.getNewValue();
+                jToggleButtonRPS.setSelected(rpsOn);
+                jToggleButtonRPS.setText(rpsOn ? "↑" : "←");
                 break;
-            case "Reactor#RodControl3731":
-                lightBulb3731.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3731.isSelected()) {
-                    jToggleButton3731.setSelected(true);
-                    jToggleButton3731.setText("↑");
-                }
+            case "Reactor#RodControl3731": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3731.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3731.setSelected(auto);
+                jToggleButton3731.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl3125":
-                lightBulb3125.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3125.isSelected()) {
-                    jToggleButton3125.setSelected(true);
-                    jToggleButton3125.setText("↑");
-                }
+            }
+            case "Reactor#RodControl3125": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3125.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3125.setSelected(auto);
+                jToggleButton3125.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl3131":
-                lightBulb3131.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3131.isSelected()) {
-                    jToggleButton3131.setSelected(true);
-                    jToggleButton3131.setText("↑");
-                }
+            }
+            case "Reactor#RodControl3131": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3131.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3131.setSelected(auto);
+                jToggleButton3131.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl3137":
-                lightBulb3137.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3137.isSelected()) {
-                    jToggleButton3137.setSelected(true);
-                    jToggleButton3137.setText("↑");
-                }
+            }
+            case "Reactor#RodControl3137": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3137.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3137.setSelected(auto);
+                jToggleButton3137.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl2531":
-                lightBulb2531.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton2531.isSelected()) {
-                    jToggleButton2531.setSelected(true);
-                    jToggleButton2531.setText("↑");
-                }
+            }
+            case "Reactor#RodControl2531": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb2531.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton2531.setSelected(auto);
+                jToggleButton2531.setText(auto ? "↑" : "←");
                 break;
+            }
             case "Reactor#GlobalControlEnabled":
                 globalControlEnabled = (boolean) evt.getNewValue();
                 lightBulbGlobalEnabled.setActive(globalControlEnabled);
                 
-                // Initialize the position of the switch button:
-                if (globalControlEnabled
-                        && !jToggleButtonGlobalEnable.isSelected()) {
-                    jToggleButtonGlobalEnable.setSelected(true);
-                    jToggleButtonGlobalEnable.setText("↑");
-                }
-                
+                // Keep the switch in sync with the model in BOTH directions,
+                // otherwise a model-forced-off (e.g. after a scram) leaves the
+                // button visually selected and the next click sends the wrong
+                // direction.
+                jToggleButtonGlobalEnable.setSelected(globalControlEnabled);
+                jToggleButtonGlobalEnable.setText(
+                        globalControlEnabled ? "↑" : "←");
+
                 // clear the setpoint display
                 if (!globalControlEnabled) {
                     jLabelReadingActiveSetpoint.setText("---,-");
@@ -2375,85 +2355,67 @@ public class PanelCoreControl extends AbstractPanelWidget {
                 lightBulbGlobalActive.setActive((boolean) evt.getNewValue());
                 break;
             case "Reactor#GlobalControlTransient":
-                lightBulbGlobalTransient.setActive((boolean) evt.getNewValue());
-                // Initialize the position of the switch button:
-                if ((boolean) evt.getNewValue()
-                        && !jToggleButtonGlobalTransient.isSelected()) {
-                    jToggleButtonGlobalTransient.setSelected(true);
-                    jToggleButtonGlobalTransient.setText("↑");
-                }
+                boolean transientOn = (boolean) evt.getNewValue();
+                lightBulbGlobalTransient.setActive(transientOn);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButtonGlobalTransient.setSelected(transientOn);
+                jToggleButtonGlobalTransient.setText(transientOn ? "↑" : "←");
                 break;
             case "Reactor#GlobalControlTarget":
-                lightBulbGlobalTarget.setActive((boolean) evt.getNewValue());
-                // Initialize the position of the switch button:
-                if ((boolean) evt.getNewValue()
-                        && !jToggleButtonGlobalTarget.isSelected()) {
-                    jToggleButtonGlobalTarget.setSelected(true);
-                    jToggleButtonGlobalTarget.setText("↑");
-                }
+                boolean targetOn = (boolean) evt.getNewValue();
+                lightBulbGlobalTarget.setActive(targetOn);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButtonGlobalTarget.setSelected(targetOn);
+                jToggleButtonGlobalTarget.setText(targetOn ? "↑" : "←");
                 break;
             case "Reactor#LocalControlEnabled":
                 boolean localControlEnabled = (boolean) evt.getNewValue();
                 lightBulbLocalEnabled.setActive(localControlEnabled);
-                
-                // Initialize the position of the switch button:
-                if (localControlEnabled
-                        && !jToggleButtonLocalEnable.isSelected()) {
-                    jToggleButtonLocalEnable.setSelected(true);
-                    jToggleButtonLocalEnable.setText("↑");
-                }
+
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButtonLocalEnable.setSelected(localControlEnabled);
+                jToggleButtonLocalEnable.setText(
+                        localControlEnabled ? "↑" : "←");
                 break;
             case "Reactor#LocalControlActive":
                 lightBulbLocalActive.setActive((boolean) evt.getNewValue());
                 break;
-            case "Reactor#RodControl3428":
-                lightBulb3428.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3428.isSelected()) {
-                    jToggleButton3428.setSelected(true);
-                    jToggleButton3428.setText("↑");
-                }
+            case "Reactor#RodControl3428": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3428.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3428.setSelected(auto);
+                jToggleButton3428.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl3434":
-                lightBulb3434.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton3434.isSelected()) {
-                    jToggleButton3434.setSelected(true);
-                    jToggleButton3434.setText("↑");
-                }
+            }
+            case "Reactor#RodControl3434": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb3434.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton3434.setSelected(auto);
+                jToggleButton3434.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl2828":
-                lightBulb2828.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton2828.isSelected()) {
-                    jToggleButton2828.setSelected(true);
-                    jToggleButton2828.setText("↑");
-                }
+            }
+            case "Reactor#RodControl2828": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb2828.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton2828.setSelected(auto);
+                jToggleButton2828.setText(auto ? "↑" : "←");
                 break;
-            case "Reactor#RodControl2834":
-                lightBulb2834.setActive(
-                        ((ControlCommand) evt.getNewValue())
-                                .equals(ControlCommand.AUTOMATIC));
-                // Initialize the position of the switch button:
-                if (((ControlCommand) evt.getNewValue())
-                        .equals(ControlCommand.AUTOMATIC)
-                        && !jToggleButton2834.isSelected()) {
-                    jToggleButton2834.setSelected(true);
-                    jToggleButton2834.setText("↑");
-                }
+            }
+            case "Reactor#RodControl2834": {
+                boolean auto = ((ControlCommand) evt.getNewValue())
+                        .equals(ControlCommand.AUTOMATIC);
+                lightBulb2834.setActive(auto);
+                // Sync the switch in both directions (see GlobalControlEnabled).
+                jToggleButton2834.setSelected(auto);
+                jToggleButton2834.setText(auto ? "↑" : "←");
                 break;
+            }
         }
         integralSwitchGlobalOverride.updateComponent(evt);
     }


### PR DESCRIPTION
Hi! These are bug fixes found while playing the simulator in **reactor-only mode**, from a focused audit of the reactor controls, rods, indicators, and calculations. Every fix here has been verified in the running app (details below); an in-progress short-rod tuning change is deliberately **left out** of this PR.

The three commits are grouped so you can review — or cherry-pick — by theme.

## 1. Reactor control fixes (`544cbfc`)
- **Manual override does nothing on auto rods.** The override branch dead-coded the controller into `AUTOMATIC` (`!globalControlActive` is never true while the override is set), and `ControlRod.run()` overwrote the position setpoint every tick while the controller was in manual/followup. Fixed both — verified live: holding the override now drives the auto rods against the controller.
- **"Stop All" button was inert** — it fires `Reactor#AllRodStop`, which had no case in `handleAction`. Added the handler. Verified live (rods freeze instead of running to full travel).
- **Toggle buttons never synced OFF.** They only updated in the ON direction, so after a scram (or a command refused while RPS active) a switch stayed visually selected and the next click sent the wrong direction. Now they sync to the model both ways. Verified live for the scram path. (Known remaining gap: a command *refused* while RPS is active fires no property-change event, so that one sub-case still can't re-sync — noted for a follow-up.)
- **Xenon reactivity used integer division** `100/3` (= 33) → `100.0/3.0`, removing a +0.333 discontinuity at yXenon=60 and the overstated high-xenon penalty.
- **Quadrant-balance sums dropped the core centre cross** (x/y == 31 fell in no quadrant) and had mismatched labels — windows now partition the whole core.

## 2. Save/load robustness (`6c60d15`, `6ea415a`)
- **A failed load bricked the app.** The `LoadSimulationState` catch only handled `IOException | ClassNotFoundException`; a version-incompatible save throws a RuntimeException that escaped to the main-loop catch, which sets `pause=true` and freezes the sim / locks out all controls until restart. Broadened the catch so a failed load is reported but the app keeps running.
- **Incompatible saves now fail clearly** instead of a raw NPE — `ReactorCore.load` validates the save (rod/fuel state present and sized to the core) and throws an "incompatible save file" message before applying any state (all-or-nothing).
- **Loading a valid save scrammed a healthy reactor.** On load the alarm history is wiped, so protection AlarmActions re-fire on conditions already true at save time — e.g. `Feed1/2Pressure` MIN1 (feed pressure is permanently below 50 bar in reactor-only mode) re-triggered `triggerAutoShutdown()`. Now auto-shutdown is suppressed for a few ticks after a load so the alarm monitors re-prime cleanly; a genuinely unsafe loaded state re-triggers once the window ends. Verified live (a saved running reactor now reloads and stays running).

## Notes
- Based on current `main`; the branch is a clean linear extension (no rebase needed).
- Transparency: these fixes were investigated and written with AI assistance (Claude Code); every one was reverse-engineered from the source and confirmed in the running app before inclusion. Happy to adjust scope, split the commits, or revise anything to fit your contribution guidelines.

Detailed write-ups with repro traces/screenshots live on the contributor fork:
Fixes voidfreud/RbmkSimulator#1, Fixes voidfreud/RbmkSimulator#3, Fixes voidfreud/RbmkSimulator#4, Fixes voidfreud/RbmkSimulator#5, Fixes voidfreud/RbmkSimulator#6, Fixes voidfreud/RbmkSimulator#19, Fixes voidfreud/RbmkSimulator#23